### PR TITLE
Enlarge the image and text previews in the subreddit view

### DIFF
--- a/app/src/main/java/com/cosmos/unreddit/data/model/preferences/ContentPreferences.kt
+++ b/app/src/main/java/com/cosmos/unreddit/data/model/preferences/ContentPreferences.kt
@@ -7,11 +7,14 @@ data class ContentPreferences(
 
     val showNsfwPreview: Boolean,
 
-    val showSpoilerPreview: Boolean
+    val showSpoilerPreview: Boolean,
+
+    val largePreview: Boolean
 ) {
     object PreferencesKeys {
         val SHOW_NSFW = booleanPreferencesKey("show_nsfw")
         val SHOW_NSFW_PREVIEW = booleanPreferencesKey("show_nsfw_preview")
         val SHOW_SPOILER_PREVIEW = booleanPreferencesKey("show_spoiler_preview")
+        val LARGE_PREVIEW = booleanPreferencesKey("large_preview")
     }
 }

--- a/app/src/main/java/com/cosmos/unreddit/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/cosmos/unreddit/data/repository/PreferencesRepository.kt
@@ -94,6 +94,20 @@ class PreferencesRepository @Inject constructor(
         )
     }
 
+    suspend fun setLargePreview(largePreview: Boolean) {
+        preferencesDatastore.setValue(
+            ContentPreferences.PreferencesKeys.LARGE_PREVIEW,
+            largePreview
+        )
+    }
+
+    fun getLargePreview(defaultValue: Boolean = false): Flow<Boolean> {
+        return preferencesDatastore.getValue(
+            ContentPreferences.PreferencesKeys.LARGE_PREVIEW,
+            defaultValue
+        )
+    }
+
     suspend fun setRedditSource(redditSource: Int) {
         preferencesDatastore.setValue(
             DataPreferences.PreferencesKeys.REDDIT_SOURCE,
@@ -157,7 +171,9 @@ class PreferencesRepository @Inject constructor(
                 preferences[ContentPreferences.PreferencesKeys.SHOW_NSFW_PREVIEW] ?: false
             val showSpoilerPreview =
                 preferences[ContentPreferences.PreferencesKeys.SHOW_SPOILER_PREVIEW] ?: false
-            ContentPreferences(showNsfw, showNsfwPreview, showSpoilerPreview)
+            val largePreview =
+                preferences[ContentPreferences.PreferencesKeys.LARGE_PREVIEW] ?: false
+            ContentPreferences(showNsfw, showNsfwPreview, showSpoilerPreview, largePreview)
         }
     }
 

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListAdapter.kt
@@ -70,11 +70,13 @@ class PostListAdapter(
     var contentPreferences: ContentPreferences = ContentPreferences(
         showNsfw = false,
         showNsfwPreview = false,
-        showSpoilerPreview = false
+        showSpoilerPreview = false,
+        largePreview = false
     )
         set(value) {
             if (field.showNsfwPreview != value.showNsfwPreview ||
-                field.showSpoilerPreview != value.showSpoilerPreview
+                field.showSpoilerPreview != value.showSpoilerPreview ||
+                field.largePreview != value.largePreview
             ) {
                 field = value
                 notifyDataSetChanged()

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListAdapter.kt
@@ -13,7 +13,6 @@ import com.cosmos.unreddit.databinding.ItemPostImageBinding
 import com.cosmos.unreddit.databinding.ItemPostLinkBinding
 import com.cosmos.unreddit.databinding.ItemPostTextBinding
 import com.cosmos.unreddit.ui.common.widget.RedditView
-import com.cosmos.unreddit.util.ClickableMovementMethod
 
 class PostListAdapter(
     private val repository: PostListRepository,
@@ -46,26 +45,6 @@ class PostListAdapter(
 
         fun onSaveClick(position: Int)
     }
-
-    private val clickableMovementMethod = ClickableMovementMethod(
-        object : ClickableMovementMethod.OnClickListener {
-            override fun onLinkClick(link: String) {
-                onLinkClickListener?.onLinkClick(link)
-            }
-
-            override fun onLinkLongClick(link: String) {
-                onLinkClickListener?.onLinkLongClick(link)
-            }
-
-            override fun onClick() {
-                // ignore
-            }
-
-            override fun onLongClick() {
-                // ignore
-            }
-        }
-    )
 
     var contentPreferences: ContentPreferences = ContentPreferences(
         showNsfw = false,
@@ -132,7 +111,7 @@ class PostListAdapter(
             PostType.TEXT.value -> PostViewHolder.TextPostViewHolder(
                 ItemPostTextBinding.inflate(inflater, parent, false),
                 listener,
-                clickableMovementMethod
+                onLinkClickListener
             )
             // Image post
             PostType.IMAGE.value -> PostViewHolder.ImagePostViewHolder(

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostViewHolder.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostViewHolder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.RecyclerView
 import com.cosmos.unreddit.R
 import com.cosmos.unreddit.data.model.MediaType
@@ -131,6 +132,23 @@ abstract class PostViewHolder(
         postMetricsBinding.buttonSave.isChecked = post.saved
     }
 
+    /**
+     * Resize the media preview according to the large preview preference.
+     */
+    protected fun View.setPreviewHeight(contentPreferences: ContentPreferences) {
+        val previewHeight = resources.getDimensionPixelSize(
+            if (contentPreferences.largePreview) {
+                R.dimen.post_image_height_large
+            } else {
+                R.dimen.post_image_height
+            }
+        )
+
+        if (layoutParams.height != previewHeight) {
+            updateLayoutParams { height = previewHeight }
+        }
+    }
+
     class ImagePostViewHolder(
         private val binding: ItemPostImageBinding,
         listener: PostListAdapter.Listener
@@ -153,6 +171,8 @@ abstract class PostViewHolder(
             contentPreferences: ContentPreferences
         ) {
             super.bind(postEntity, contentPreferences)
+
+            binding.imagePostPreview.setPreviewHeight(contentPreferences)
 
             binding.imagePostPreview.load(
                 postEntity.preview,
@@ -199,6 +219,8 @@ abstract class PostViewHolder(
             contentPreferences: ContentPreferences
         ) {
             super.bind(postEntity, contentPreferences)
+
+            binding.imagePostPreview.setPreviewHeight(contentPreferences)
 
             binding.imagePostPreview.load(
                 postEntity.preview,

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostViewHolder.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostViewHolder.kt
@@ -2,6 +2,7 @@ package com.cosmos.unreddit.ui.postlist
 
 import android.view.View
 import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -17,6 +18,7 @@ import com.cosmos.unreddit.databinding.ItemPostImageBinding
 import com.cosmos.unreddit.databinding.ItemPostLinkBinding
 import com.cosmos.unreddit.databinding.ItemPostTextBinding
 import com.cosmos.unreddit.ui.common.widget.AwardView
+import com.cosmos.unreddit.ui.common.widget.RedditView
 import com.cosmos.unreddit.util.ClickableMovementMethod
 import com.cosmos.unreddit.util.extension.load
 import com.cosmos.unreddit.util.extension.setRatio
@@ -149,6 +151,28 @@ abstract class PostViewHolder(
         }
     }
 
+    /**
+     * Resize the text preview according to the large preview preference. The preview wraps its
+     * content, so only the maximum height is constrained.
+     */
+    protected fun View.setPreviewMaxHeight(contentPreferences: ContentPreferences) {
+        val previewMaxHeight = resources.getDimensionPixelSize(
+            if (contentPreferences.largePreview) {
+                R.dimen.post_text_max_height_large
+            } else {
+                R.dimen.post_text_max_height
+            }
+        )
+
+        val params = layoutParams as? ConstraintLayout.LayoutParams ?: return
+
+        if (params.matchConstraintMaxHeight != previewMaxHeight) {
+            updateLayoutParams<ConstraintLayout.LayoutParams> {
+                matchConstraintMaxHeight = previewMaxHeight
+            }
+        }
+    }
+
     class ImagePostViewHolder(
         private val binding: ItemPostImageBinding,
         listener: PostListAdapter.Listener
@@ -240,7 +264,7 @@ abstract class PostViewHolder(
     class TextPostViewHolder(
         private val binding: ItemPostTextBinding,
         listener: PostListAdapter.Listener,
-        clickableMovementMethod: ClickableMovementMethod
+        onLinkClickListener: RedditView.OnLinkClickListener?
     ) : PostViewHolder(
         binding.root,
         binding.includePostInfo,
@@ -250,11 +274,27 @@ abstract class PostViewHolder(
     ) {
 
         init {
-            binding.textPostSelf.movementMethod = clickableMovementMethod
-            binding.textPostSelf.setOnLongClickListener {
-                listener.onClick(bindingAdapterPosition, true)
-                true
-            }
+            // The preview consumes the touch events, so the clicks made outside of a link have to
+            // be forwarded to the post itself
+            binding.textPostSelf.movementMethod = ClickableMovementMethod(
+                object : ClickableMovementMethod.OnClickListener {
+                    override fun onLinkClick(link: String) {
+                        onLinkClickListener?.onLinkClick(link)
+                    }
+
+                    override fun onLinkLongClick(link: String) {
+                        onLinkClickListener?.onLinkLongClick(link)
+                    }
+
+                    override fun onClick() {
+                        listener.onClick(bindingAdapterPosition)
+                    }
+
+                    override fun onLongClick() {
+                        listener.onClick(bindingAdapterPosition, true)
+                    }
+                }
+            )
         }
 
         override fun bind(
@@ -264,6 +304,8 @@ abstract class PostViewHolder(
             super.bind(postEntity, contentPreferences)
 
             val previewText = postEntity.previewText
+
+            binding.textPostSelfCard.setPreviewMaxHeight(contentPreferences)
 
             binding.textPostSelf.apply {
                 if (postEntity.shouldShowPreview(contentPreferences) && previewText != null) {

--- a/app/src/main/java/com/cosmos/unreddit/ui/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/preferences/PreferencesFragment.kt
@@ -49,6 +49,7 @@ class PreferencesFragment : PreferenceFragmentCompat() {
     private var showNsfwPreference: SwitchPreferenceCompat? = null
     private var showNsfwPreviewPreference: SwitchPreferenceCompat? = null
     private var showSpoilerPreviewPreference: SwitchPreferenceCompat? = null
+    private var largePreviewPreference: SwitchPreferenceCompat? = null
     private var backupPreference: Preference? = null
     private var sourcePreference: Preference? = null
     private var privacyEnhancerPreference: Preference? = null
@@ -135,6 +136,15 @@ class PreferencesFragment : PreferenceFragmentCompat() {
         )?.apply {
             setOnPreferenceChangeListener { _, newValue ->
                 viewModel.setShowSpoilerPreview(newValue as Boolean)
+                true
+            }
+        }
+
+        largePreviewPreference = findPreference<SwitchPreferenceCompat>(
+            PreferencesKeys.LARGE_PREVIEW.name
+        )?.apply {
+            setOnPreferenceChangeListener { _, newValue ->
+                viewModel.setLargePreview(newValue as Boolean)
                 true
             }
         }
@@ -251,6 +261,12 @@ class PreferencesFragment : PreferenceFragmentCompat() {
             launch {
                 viewModel.showSpoilerPreview.collect { showSpoilerPreview ->
                     showSpoilerPreviewPreference?.isChecked = showSpoilerPreview
+                }
+            }
+
+            launch {
+                viewModel.largePreview.collect { largePreview ->
+                    largePreviewPreference?.isChecked = largePreview
                 }
             }
 

--- a/app/src/main/java/com/cosmos/unreddit/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/preferences/PreferencesViewModel.kt
@@ -36,6 +36,8 @@ class PreferencesViewModel @Inject constructor(
 
     val showSpoilerPreview: Flow<Boolean> = preferencesRepository.getShowSpoilerPreview()
 
+    val largePreview: Flow<Boolean> = preferencesRepository.getLargePreview()
+
     val redditSource: SharedFlow<Pair<Int, String>> = combine(
         preferencesRepository.getRedditSource(),
         preferencesRepository.getRedditSourceInstance("teddit.net")
@@ -95,6 +97,12 @@ class PreferencesViewModel @Inject constructor(
     fun setShowSpoilerPreview(showSpoilerPreview: Boolean) {
         viewModelScope.launch {
             preferencesRepository.setShowSpoilerPreview(showSpoilerPreview)
+        }
+    }
+
+    fun setLargePreview(largePreview: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.setLargePreview(largePreview)
         }
     }
 

--- a/app/src/main/java/com/cosmos/unreddit/ui/profile/ProfileSavedAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/profile/ProfileSavedAdapter.kt
@@ -23,7 +23,6 @@ import com.cosmos.unreddit.ui.common.widget.RedditView
 import com.cosmos.unreddit.ui.postlist.PostListAdapter
 import com.cosmos.unreddit.ui.postlist.PostViewHolder
 import com.cosmos.unreddit.ui.user.UserCommentsAdapter
-import com.cosmos.unreddit.util.ClickableMovementMethod
 import com.cosmos.unreddit.util.DateUtil
 import com.cosmos.unreddit.util.extension.blurText
 
@@ -37,26 +36,6 @@ class ProfileSavedAdapter(
     private val colorPrimary by lazy {
         ColorStateList.valueOf(ContextCompat.getColor(context, R.color.colorPrimary))
     }
-
-    private val clickableMovementMethod = ClickableMovementMethod(
-        object : ClickableMovementMethod.OnClickListener {
-            override fun onLinkClick(link: String) {
-                onLinkClickListener?.onLinkClick(link)
-            }
-
-            override fun onLinkLongClick(link: String) {
-                onLinkClickListener?.onLinkLongClick(link)
-            }
-
-            override fun onClick() {
-                // ignore
-            }
-
-            override fun onLongClick() {
-                // ignore
-            }
-        }
-    )
 
     var contentPreferences: ContentPreferences = ContentPreferences(
         showNsfw = false,
@@ -121,7 +100,7 @@ class ProfileSavedAdapter(
             PostType.TEXT.value -> PostViewHolder.TextPostViewHolder(
                 ItemPostTextBinding.inflate(inflater, parent, false),
                 listener,
-                clickableMovementMethod
+                onLinkClickListener
             )
             // Image post
             PostType.IMAGE.value -> PostViewHolder.ImagePostViewHolder(

--- a/app/src/main/java/com/cosmos/unreddit/ui/profile/ProfileSavedAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/profile/ProfileSavedAdapter.kt
@@ -61,11 +61,13 @@ class ProfileSavedAdapter(
     var contentPreferences: ContentPreferences = ContentPreferences(
         showNsfw = false,
         showNsfwPreview = false,
-        showSpoilerPreview = false
+        showSpoilerPreview = false,
+        largePreview = false
     )
         set(value) {
             if (field.showNsfwPreview != value.showNsfwPreview ||
-                field.showSpoilerPreview != value.showSpoilerPreview
+                field.showSpoilerPreview != value.showSpoilerPreview ||
+                field.largePreview != value.largePreview
             ) {
                 field = value
                 notifyDataSetChanged()

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,6 +14,7 @@
 
     <dimen name="post_text_padding">16dp</dimen>
     <dimen name="post_text_max_height">200dp</dimen>
+    <dimen name="post_text_max_height_large">400dp</dimen>
     <dimen name="post_text_card_radius">15dp</dimen>
 
     <dimen name="post_image_height">250dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <dimen name="post_text_card_radius">15dp</dimen>
 
     <dimen name="post_image_height">250dp</dimen>
+    <dimen name="post_image_height_large">500dp</dimen>
 
     <dimen name="post_link_image_size">100dp</dimen>
     <dimen name="post_link_image_margin_horizontal">8dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,7 +152,7 @@
     <string name="preference_show_nsfw_preview">Show NSFW preview</string>
     <string name="preference_show_spoiler_preview">Show Spoiler preview</string>
     <string name="preference_large_preview">Large previews</string>
-    <string name="preference_large_preview_summary">Double the height of image and video previews in post lists</string>
+    <string name="preference_large_preview_summary">Double the height of image, video and text previews in post lists</string>
 
     <string name="preference_reddit_source">Reddit Source</string>
     <string name="preference_reddit_source_reddit">Reddit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,8 @@
     <string name="preference_show_nsfw">Show NSFW content</string>
     <string name="preference_show_nsfw_preview">Show NSFW preview</string>
     <string name="preference_show_spoiler_preview">Show Spoiler preview</string>
+    <string name="preference_large_preview">Large previews</string>
+    <string name="preference_large_preview_summary">Double the height of image and video previews in post lists</string>
 
     <string name="preference_reddit_source">Reddit Source</string>
     <string name="preference_reddit_source_reddit">Reddit</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -37,6 +37,12 @@
             app:title="@string/preference_show_spoiler_preview"
             app:persistent="false"/>
 
+        <SwitchPreferenceCompat
+            app:key="large_preview"
+            app:title="@string/preference_large_preview"
+            app:summary="@string/preference_large_preview_summary"
+            app:persistent="false"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
@RohitSurwase 

This adds a non-defaulted option to double the height of the preview in the subreddit card. This is a nice UX improvement on a tablet and also fixes a slightly annoying issue on text previews where you can't tap on the preview to go to the post.