### PR TITLE
Add the ability to remove a subscription, and profile add/remove support

### DIFF
--- a/app/src/main/java/com/cosmos/unreddit/ui/common/ProfileNameDialog.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/common/ProfileNameDialog.kt
@@ -1,0 +1,84 @@
+package com.cosmos.unreddit.ui.common
+
+import android.content.DialogInterface
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import com.cosmos.unreddit.R
+import com.cosmos.unreddit.databinding.DialogAddProfileBinding
+import com.cosmos.unreddit.util.extension.text
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+
+/**
+ * Name prompt used when creating or renaming a profile.
+ *
+ * Shared by the profile manager and the home profile panel so both enforce the same naming rules.
+ */
+object ProfileNameDialog {
+
+    private const val PROFILE_NAME_MIN = 3
+    private const val PROFILE_NAME_MAX = 20
+
+    /**
+     * [onValidName] is invoked only once [existingNames] and the length rules are satisfied; on a
+     * validation error the dialog stays open and shows the error inline instead.
+     */
+    fun show(
+        fragment: Fragment,
+        @StringRes title: Int,
+        @StringRes positiveButton: Int,
+        existingNames: List<String>,
+        initialName: String? = null,
+        onValidName: (String) -> Unit
+    ) {
+        val profileBinding = DialogAddProfileBinding.inflate(
+            fragment.requireActivity().layoutInflater
+        ).apply {
+            initialName?.let { inputName.editText?.setText(it) }
+        }
+
+        MaterialAlertDialogBuilder(fragment.requireContext())
+            .setView(profileBinding.root)
+            .setTitle(title)
+            .setPositiveButton(positiveButton) { _, _ ->
+                // Handled below so an invalid name does not dismiss the dialog
+            }
+            .setNeutralButton(R.string.dialog_cancel) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .setCancelable(false)
+            .show()
+            .apply {
+                getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
+                    val name = profileBinding.inputName.text().toString()
+                    val errorMessage = validate(fragment, name, existingNames)
+                    if (errorMessage == null) {
+                        onValidName(name)
+                        dismiss()
+                    } else {
+                        profileBinding.inputName.error = errorMessage
+                    }
+                }
+            }
+    }
+
+    private fun validate(
+        fragment: Fragment,
+        text: String,
+        existingNames: List<String>
+    ): String? {
+        return when {
+            text.length !in PROFILE_NAME_MIN..PROFILE_NAME_MAX -> {
+                fragment.getString(R.string.profile_name_length_error)
+            }
+            existingNames.any { it.equals(text, true) } -> {
+                fragment.getString(R.string.profile_already_exists_error)
+            }
+            text.isBlank() -> {
+                fragment.getString(R.string.profile_blank_error)
+            }
+            else -> {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cosmos/unreddit/ui/common/fragment/ListFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/common/fragment/ListFragment.kt
@@ -10,7 +10,6 @@ import androidx.recyclerview.widget.RecyclerView.Adapter
 import androidx.recyclerview.widget.RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.cosmos.unreddit.R
-import com.cosmos.unreddit.data.model.db.PostEntity
 import com.cosmos.unreddit.databinding.ItemListContentBinding
 import com.cosmos.unreddit.ui.base.BaseFragment
 import com.cosmos.unreddit.ui.common.PostDividerItemDecoration
@@ -18,7 +17,6 @@ import com.cosmos.unreddit.ui.common.widget.PullToRefreshLayout
 import com.cosmos.unreddit.ui.common.widget.PullToRefreshView
 import com.cosmos.unreddit.util.DateUtil
 import com.cosmos.unreddit.util.extension.applyWindowInsets
-import com.cosmos.unreddit.util.extension.currentNavigationFragment
 
 abstract class ListFragment<T : Adapter<out ViewHolder>> : BaseFragment(),
     PullToRefreshLayout.OnRefreshListener {
@@ -49,12 +47,6 @@ abstract class ListFragment<T : Adapter<out ViewHolder>> : BaseFragment(),
         super.onViewCreated(view, savedInstanceState)
         initRecyclerView()
         binding.pullRefresh.enablePullToRefresh = enablePullToRefresh
-    }
-
-    override fun onClick(post: PostEntity) {
-        activity?.currentNavigationFragment?.let { currentFragment ->
-            onClick(currentFragment.parentFragmentManager, post)
-        }
     }
 
     protected open fun initRecyclerView() {

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
+import android.widget.Toast
 import androidx.core.view.GravityCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -19,10 +20,12 @@ import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.cosmos.unreddit.R
 import com.cosmos.unreddit.UiViewModel
+import com.cosmos.unreddit.data.model.ProfileItem
 import com.cosmos.unreddit.data.model.db.Profile
 import com.cosmos.unreddit.data.repository.PostListRepository
 import com.cosmos.unreddit.databinding.FragmentPostBinding
 import com.cosmos.unreddit.ui.base.BaseFragment
+import com.cosmos.unreddit.ui.common.ProfileNameDialog
 import com.cosmos.unreddit.ui.common.widget.PullToRefreshLayout
 import com.cosmos.unreddit.ui.common.widget.PullToRefreshView
 import com.cosmos.unreddit.ui.loadstate.NetworkLoadStateAdapter
@@ -40,6 +43,7 @@ import com.cosmos.unreddit.util.extension.onRefreshFromNetwork
 import com.cosmos.unreddit.util.extension.setNavigationListener
 import com.cosmos.unreddit.util.extension.setSortingListener
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -83,6 +87,8 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
     private lateinit var postListAdapter: PostListAdapter
 
     private lateinit var profileAdapter: ProfileAdapter
+
+    private var currentProfileId: Int? = null
 
     @Inject
     lateinit var repository: PostListRepository
@@ -173,6 +179,7 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
 
             launch {
                 viewModel.currentProfile.collect {
+                    currentProfileId = it.id
                     binding.appBar.profileImage.setText(it.name)
                 }
             }
@@ -204,7 +211,11 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
             })
         }
 
-        profileAdapter = ProfileAdapter { onProfileClick(it) }
+        profileAdapter = ProfileAdapter(
+            onClickListener = { onProfileClick(it) },
+            onLongClickListener = { onProfileLongClick(it) },
+            onNewProfileClickListener = { onNewProfileClick() }
+        )
 
         binding.listProfiles.apply {
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
@@ -322,6 +333,48 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
         closeProfileDrawer()
         // Show app bar on profile change to prevent weird scrolling behaviors
         binding.appBarLayout.setExpanded(true)
+    }
+
+    private fun onProfileLongClick(profile: Profile) {
+        if (profile.id == currentProfileId) {
+            // Same rule as the profile manager, which hides its delete icon for the active
+            // profile: deleting it would leave the app pointing at a profile that no longer
+            // exists. Long pressing it is silent otherwise, so explain why nothing happened.
+            Toast.makeText(
+                requireContext(),
+                R.string.profile_delete_current_error,
+                Toast.LENGTH_SHORT
+            ).show()
+        } else {
+            showDeleteProfileDialog(profile)
+        }
+    }
+
+    private fun onNewProfileClick() {
+        ProfileNameDialog.show(
+            fragment = this,
+            title = R.string.dialog_create_profile_title,
+            positiveButton = R.string.dialog_create_profile_button,
+            existingNames = profileAdapter.currentList
+                .filterIsInstance<ProfileItem.UserProfile>()
+                .map { it.profile.name }
+        ) { name ->
+            viewModel.addProfile(name)
+        }
+    }
+
+    private fun showDeleteProfileDialog(profile: Profile) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.dialog_delete_profile_title)
+            .setMessage(getString(R.string.dialog_delete_profile_named_message, profile.name))
+            .setPositiveButton(R.string.dialog_yes) { _, _ ->
+                viewModel.deleteProfile(profile)
+            }
+            .setNegativeButton(R.string.dialog_no) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .setCancelable(false)
+            .show()
     }
 
     override fun onRefresh() {

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListFragment.kt
@@ -88,8 +88,6 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
 
     private lateinit var profileAdapter: ProfileAdapter
 
-    private var currentProfileId: Int? = null
-
     @Inject
     lateinit var repository: PostListRepository
 
@@ -179,7 +177,7 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
 
             launch {
                 viewModel.currentProfile.collect {
-                    currentProfileId = it.id
+                    profileAdapter.currentProfileId = it.id
                     binding.appBar.profileImage.setText(it.name)
                 }
             }
@@ -336,7 +334,7 @@ class PostListFragment : BaseFragment(), PullToRefreshLayout.OnRefreshListener {
     }
 
     private fun onProfileLongClick(profile: Profile) {
-        if (profile.id == currentProfileId) {
+        if (profile.id == profileAdapter.currentProfileId) {
             // Same rule as the profile manager, which hides its delete icon for the active
             // profile: deleting it would leave the app pointing at a profile that no longer
             // exists. Long pressing it is silent otherwise, so explain why nothing happened.

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListViewModel.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/PostListViewModel.kt
@@ -8,6 +8,7 @@ import com.cosmos.unreddit.data.model.Data
 import com.cosmos.unreddit.data.model.Sort
 import com.cosmos.unreddit.data.model.Sorting
 import com.cosmos.unreddit.data.model.db.PostEntity
+import com.cosmos.unreddit.data.model.ProfileItem
 import com.cosmos.unreddit.data.model.db.Profile
 import com.cosmos.unreddit.data.model.preferences.ContentPreferences
 import com.cosmos.unreddit.data.repository.PostListRepository
@@ -46,7 +47,15 @@ class PostListViewModel
     val contentPreferences: Flow<ContentPreferences> =
         preferencesRepository.getContentPreferences()
 
-    val profiles: Flow<List<Profile>> = repository.getAllProfiles()
+    val profiles: Flow<List<ProfileItem>> = repository.getAllProfiles()
+        .map { profiles ->
+            mutableListOf<ProfileItem>().apply {
+                addAll(profiles.map { ProfileItem.UserProfile(it) })
+                // Trailing entry that opens the create-profile dialog
+                add(ProfileItem.NewProfile)
+            }
+        }
+        .flowOn(defaultDispatcher)
 
     private val _sorting: MutableStateFlow<Sorting> = MutableStateFlow(DEFAULT_SORTING)
     val sorting: StateFlow<Sorting> = _sorting
@@ -115,6 +124,18 @@ class PostListViewModel
     fun selectProfile(profile: Profile) {
         viewModelScope.launch {
             preferencesRepository.setCurrentProfile(profile.id)
+        }
+    }
+
+    fun deleteProfile(profile: Profile) {
+        viewModelScope.launch {
+            repository.deleteProfile(profile.id)
+        }
+    }
+
+    fun addProfile(name: String) {
+        viewModelScope.launch {
+            repository.addProfile(name)
         }
     }
 

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/ProfileAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/ProfileAdapter.kt
@@ -5,20 +5,44 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.cosmos.unreddit.data.model.ProfileItem
 import com.cosmos.unreddit.data.model.db.Profile
+import com.cosmos.unreddit.databinding.ItemNewProfileHomeBinding
 import com.cosmos.unreddit.databinding.ItemProfileHomeBinding
 
 class ProfileAdapter(
-    val onClickListener: (Profile) -> Unit
-) : ListAdapter<Profile, ProfileAdapter.ViewHolder>(PROFILE_COMPARATOR) {
+    val onClickListener: (Profile) -> Unit,
+    val onLongClickListener: (Profile) -> Unit,
+    val onNewProfileClickListener: () -> Unit
+) : ListAdapter<ProfileItem, RecyclerView.ViewHolder>(PROFILE_COMPARATOR) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        return ViewHolder(ItemProfileHomeBinding.inflate(inflater, parent, false))
+        return when (viewType) {
+            Type.PROFILE.value -> {
+                ViewHolder(ItemProfileHomeBinding.inflate(inflater, parent, false))
+            }
+            Type.NEW_PROFILE.value -> {
+                NewProfileViewHolder(ItemNewProfileHomeBinding.inflate(inflater, parent, false))
+            }
+            else -> throw IllegalArgumentException("Unknown type $viewType")
+        }
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (val item = getItem(position)) {
+            is ProfileItem.UserProfile -> (holder as ViewHolder).bind(item.profile)
+            is ProfileItem.NewProfile -> {
+                // Nothing to bind, the click listener is set once in the view holder
+            }
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is ProfileItem.UserProfile -> Type.PROFILE.value
+            is ProfileItem.NewProfile -> Type.NEW_PROFILE.value
+        }
     }
 
     inner class ViewHolder(
@@ -28,16 +52,41 @@ class ProfileAdapter(
         fun bind(profile: Profile) {
             binding.profile = profile
             binding.profileAvatar.setOnClickListener { onClickListener.invoke(profile) }
+            binding.profileAvatar.setOnLongClickListener {
+                onLongClickListener.invoke(profile)
+                // Consume the event so the long press never falls through to the click listener,
+                // which would switch to the profile the user is trying to delete.
+                true
+            }
         }
     }
 
+    inner class NewProfileViewHolder(
+        binding: ItemNewProfileHomeBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.imageAdd.setOnClickListener { onNewProfileClickListener.invoke() }
+        }
+    }
+
+    private enum class Type(val value: Int) {
+        PROFILE(0), NEW_PROFILE(1)
+    }
+
     companion object {
-        private val PROFILE_COMPARATOR = object : DiffUtil.ItemCallback<Profile>() {
-            override fun areItemsTheSame(oldItem: Profile, newItem: Profile): Boolean {
-                return oldItem.id == newItem.id
+        private val PROFILE_COMPARATOR = object : DiffUtil.ItemCallback<ProfileItem>() {
+            override fun areItemsTheSame(oldItem: ProfileItem, newItem: ProfileItem): Boolean {
+                return if (oldItem is ProfileItem.UserProfile &&
+                    newItem is ProfileItem.UserProfile
+                ) {
+                    oldItem.profile.id == newItem.profile.id
+                } else {
+                    oldItem is ProfileItem.NewProfile && newItem is ProfileItem.NewProfile
+                }
             }
 
-            override fun areContentsTheSame(oldItem: Profile, newItem: Profile): Boolean {
+            override fun areContentsTheSame(oldItem: ProfileItem, newItem: ProfileItem): Boolean {
                 return oldItem == newItem
             }
         }

--- a/app/src/main/java/com/cosmos/unreddit/ui/postlist/ProfileAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/postlist/ProfileAdapter.kt
@@ -1,10 +1,14 @@
 package com.cosmos.unreddit.ui.postlist
 
+import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.cosmos.unreddit.R
 import com.cosmos.unreddit.data.model.ProfileItem
 import com.cosmos.unreddit.data.model.db.Profile
 import com.cosmos.unreddit.databinding.ItemNewProfileHomeBinding
@@ -15,6 +19,29 @@ class ProfileAdapter(
     val onLongClickListener: (Profile) -> Unit,
     val onNewProfileClickListener: () -> Unit
 ) : ListAdapter<ProfileItem, RecyclerView.ViewHolder>(PROFILE_COMPARATOR) {
+
+    /**
+     * Id of the profile currently in use, highlighted in the tray. Setting it rebinds only the rows
+     * that gain or lose the highlight.
+     */
+    var currentProfileId: Int? = null
+        set(value) {
+            if (field == value) return
+
+            val previous = field
+            field = value
+
+            listOf(previous, value).forEach { id ->
+                indexOfProfile(id).takeIf { it != RecyclerView.NO_POSITION }
+                    ?.let { notifyItemChanged(it) }
+            }
+        }
+
+    private fun indexOfProfile(profileId: Int?): Int {
+        return profileId?.let { id ->
+            currentList.indexOfFirst { it is ProfileItem.UserProfile && it.profile.id == id }
+        } ?: RecyclerView.NO_POSITION
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -51,6 +78,19 @@ class ProfileAdapter(
 
         fun bind(profile: Profile) {
             binding.profile = profile
+
+            val isCurrent = profile.id == currentProfileId
+            binding.profileSelectedRing.isVisible = isCurrent
+            binding.profileName.run {
+                setTypeface(null, if (isCurrent) Typeface.BOLD else Typeface.NORMAL)
+                setTextColor(
+                    ContextCompat.getColor(
+                        context,
+                        if (isCurrent) R.color.colorPrimary else R.color.text_color_secondary
+                    )
+                )
+            }
+
             binding.profileAvatar.setOnClickListener { onClickListener.invoke(profile) }
             binding.profileAvatar.setOnLongClickListener {
                 onLongClickListener.invoke(profile)

--- a/app/src/main/java/com/cosmos/unreddit/ui/profilemanager/ProfileManagerDialogFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/profilemanager/ProfileManagerDialogFragment.kt
@@ -1,6 +1,5 @@
 package com.cosmos.unreddit.ui.profilemanager
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -16,13 +15,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.cosmos.unreddit.R
 import com.cosmos.unreddit.data.model.ProfileItem
 import com.cosmos.unreddit.data.model.db.Profile
-import com.cosmos.unreddit.databinding.DialogAddProfileBinding
 import com.cosmos.unreddit.databinding.FragmentProfileManagerBinding
 import com.cosmos.unreddit.ui.common.CarouselPageTransformer
+import com.cosmos.unreddit.ui.common.ProfileNameDialog
 import com.cosmos.unreddit.util.extension.doAndDismiss
 import com.cosmos.unreddit.util.extension.getRecyclerView
 import com.cosmos.unreddit.util.extension.parcelable
-import com.cosmos.unreddit.util.extension.text
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -86,82 +84,32 @@ class ProfileManagerDialogFragment : DialogFragment(), ProfileManagerAdapter.Pro
     }
 
     private fun showAddProfileDialog() {
-        val profileBinding = DialogAddProfileBinding.inflate(
-            requireActivity().layoutInflater
-        )
-        MaterialAlertDialogBuilder(requireContext())
-            .setView(profileBinding.root)
-            .setTitle(R.string.dialog_create_profile_title)
-            .setPositiveButton(R.string.dialog_create_profile_button) { _, _ ->
-                // Ignore
-            }
-            .setNeutralButton(R.string.dialog_cancel) { dialog, _ ->
-                dialog.dismiss()
-            }
-            .setCancelable(false)
-            .show()
-            .apply {
-                getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
-                    val name = profileBinding.inputName.text().toString()
-                    val errorMessage = validateProfile(name)
-                    if (errorMessage == null) {
-                        name.let { viewModel.addProfile(it) }
-                        this.dismiss()
-                    } else {
-                        profileBinding.inputName.error = errorMessage
-                    }
-                }
-            }
+        ProfileNameDialog.show(
+            fragment = this,
+            title = R.string.dialog_create_profile_title,
+            positiveButton = R.string.dialog_create_profile_button,
+            existingNames = existingProfileNames()
+        ) { name ->
+            viewModel.addProfile(name)
+        }
     }
 
     private fun showRenameProfileDialog(profile: Profile) {
-        val profileBinding = DialogAddProfileBinding.inflate(
-            requireActivity().layoutInflater
-        ).apply {
-            inputName.editText?.setText(profile.name)
+        ProfileNameDialog.show(
+            fragment = this,
+            title = R.string.dialog_rename_profile_title,
+            positiveButton = R.string.dialog_rename_profile_button,
+            existingNames = existingProfileNames(),
+            initialName = profile.name
+        ) { name ->
+            viewModel.renameProfile(profile, name)
         }
-        MaterialAlertDialogBuilder(requireContext())
-            .setView(profileBinding.root)
-            .setTitle(R.string.dialog_rename_profile_title)
-            .setPositiveButton(R.string.dialog_rename_profile_button) { _, _ ->
-                // Ignore
-            }
-            .setNeutralButton(R.string.dialog_cancel) { dialog, _ ->
-                dialog.dismiss()
-            }
-            .setCancelable(false)
-            .show()
-            .apply {
-                getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
-                    val name = profileBinding.inputName.text().toString()
-                    val errorMessage = validateProfile(name)
-                    if (errorMessage == null) {
-                        name.let { viewModel.renameProfile(profile, it) }
-                        this.dismiss()
-                    } else {
-                        profileBinding.inputName.error = errorMessage
-                    }
-                }
-            }
     }
 
-    private fun validateProfile(text: String): String? {
-        return when {
-            text.length !in PROFILE_NAME_MIN..PROFILE_NAME_MAX -> {
-                getString(R.string.profile_name_length_error)
-            }
-            profileAdapter.currentList.any {
-                it is ProfileItem.UserProfile && it.profile.name.equals(text, true)
-            } -> {
-                getString(R.string.profile_already_exists_error)
-            }
-            text.isBlank() -> {
-                getString(R.string.profile_blank_error)
-            }
-            else -> {
-                null
-            }
-        }
+    private fun existingProfileNames(): List<String> {
+        return profileAdapter.currentList
+            .filterIsInstance<ProfileItem.UserProfile>()
+            .map { it.profile.name }
     }
 
     private fun showDeleteProfileDialog(profile: Profile) {
@@ -205,9 +153,6 @@ class ProfileManagerDialogFragment : DialogFragment(), ProfileManagerAdapter.Pro
 
     companion object {
         private const val TAG = "ProfileManagerDialogFragment"
-
-        private const val PROFILE_NAME_MIN = 3
-        private const val PROFILE_NAME_MAX = 20
 
         private const val KEY_CURRENT_PROFILE = "KEY_PROFILE"
 

--- a/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsAdapter.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsAdapter.kt
@@ -13,7 +13,8 @@ import com.cosmos.unreddit.data.model.db.Subscription
 import com.cosmos.unreddit.databinding.ItemSubscriptionBinding
 
 class SubscriptionsAdapter(
-    private val listener: (String) -> Unit
+    private val listener: (String) -> Unit,
+    private val longClickListener: (Subscription) -> Unit
 ) : ListAdapter<Subscription, SubscriptionsAdapter.SubscriptionViewHolder>(
     SUBSCRIPTION_COMPARATOR
 ) {
@@ -45,6 +46,11 @@ class SubscriptionsAdapter(
 
             itemView.setOnClickListener {
                 listener(subscription.name)
+            }
+
+            itemView.setOnLongClickListener {
+                longClickListener(subscription)
+                true
             }
         }
     }

--- a/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsFragment.kt
@@ -12,11 +12,14 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.cosmos.unreddit.NavigationGraphDirections
+import com.cosmos.unreddit.R
+import com.cosmos.unreddit.data.model.db.Subscription
 import com.cosmos.unreddit.databinding.FragmentSubscriptionsBinding
 import com.cosmos.unreddit.ui.base.BaseFragment
 import com.cosmos.unreddit.util.SearchUtil
 import com.cosmos.unreddit.util.extension.applyWindowInsets
 import com.cosmos.unreddit.util.extension.hideSoftKeyboard
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -68,7 +71,10 @@ class SubscriptionsFragment : BaseFragment() {
     }
 
     private fun initRecyclerView() {
-        subscriptionsAdapter = SubscriptionsAdapter { onClick(it) }
+        subscriptionsAdapter = SubscriptionsAdapter(
+            { onClick(it) },
+            { showUnsubscribeDialog(it) }
+        )
         binding.listSubscriptions.apply {
             applyWindowInsets(left = false, top = false, right = false)
             layoutManager = LinearLayoutManager(requireContext())
@@ -117,6 +123,19 @@ class SubscriptionsFragment : BaseFragment() {
 
     private fun onClick(subreddit: String) {
         navigate(NavigationGraphDirections.openSubreddit(subreddit))
+    }
+
+    private fun showUnsubscribeDialog(subscription: Subscription) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.dialog_unsubscribe_title)
+            .setMessage(getString(R.string.dialog_unsubscribe_message, subscription.name))
+            .setPositiveButton(R.string.dialog_yes) { _, _ ->
+                viewModel.unsubscribe(subscription)
+            }
+            .setNegativeButton(R.string.dialog_no) { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
     }
 
     private fun handleSearchAction(query: String) {

--- a/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsFragment.kt
@@ -1,6 +1,7 @@
 package com.cosmos.unreddit.ui.subscriptions
 
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +20,7 @@ import com.cosmos.unreddit.ui.base.BaseFragment
 import com.cosmos.unreddit.util.SearchUtil
 import com.cosmos.unreddit.util.extension.applyWindowInsets
 import com.cosmos.unreddit.util.extension.hideSoftKeyboard
+import com.cosmos.unreddit.util.extension.parcelable
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -33,6 +35,10 @@ class SubscriptionsFragment : BaseFragment() {
 
     private lateinit var subscriptionsAdapter: SubscriptionsAdapter
 
+    // Scroll position of the list, saved when the view is destroyed and restored once the
+    // subscriptions have been submitted to the adapter
+    private var listState: Parcelable? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -44,6 +50,7 @@ class SubscriptionsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        savedInstanceState?.parcelable<Parcelable>(KEY_LIST_STATE)?.let { listState = it }
         initAppBar()
         initRecyclerView()
         bindViewModel()
@@ -61,7 +68,11 @@ class SubscriptionsFragment : BaseFragment() {
             viewModel.filteredSubscriptions
                 .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
                 .collect { subscriptions ->
-                    subscriptionsAdapter.submitList(subscriptions)
+                    subscriptionsAdapter.submitList(subscriptions) {
+                        if (subscriptions.isNotEmpty()) {
+                            restoreListState()
+                        }
+                    }
                     if (binding.appBar.searchInput.isQueryEmpty()) {
                         binding.emptyData.isVisible = subscriptions.isEmpty()
                         binding.textEmptyData.isVisible = subscriptions.isEmpty()
@@ -80,6 +91,16 @@ class SubscriptionsFragment : BaseFragment() {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = subscriptionsAdapter
         }
+    }
+
+    private fun saveListState() {
+        _binding?.listSubscriptions?.layoutManager?.onSaveInstanceState()?.let { listState = it }
+    }
+
+    private fun restoreListState() {
+        val state = listState ?: return
+        listState = null
+        _binding?.listSubscriptions?.layoutManager?.onRestoreInstanceState(state)
     }
 
     private fun initAppBar() {
@@ -153,12 +174,21 @@ class SubscriptionsFragment : BaseFragment() {
         }
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        saveListState()
+        outState.putParcelable(KEY_LIST_STATE, listState)
+    }
+
     override fun onDestroyView() {
+        saveListState()
         super.onDestroyView()
         _binding = null
     }
 
     companion object {
         const val TAG = "SubscriptionsFragment"
+
+        private const val KEY_LIST_STATE = "list_state"
     }
 }

--- a/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/cosmos/unreddit/ui/subscriptions/SubscriptionsViewModel.kt
@@ -1,10 +1,12 @@
 package com.cosmos.unreddit.ui.subscriptions
 
+import androidx.lifecycle.viewModelScope
 import com.cosmos.unreddit.data.model.db.Subscription
 import com.cosmos.unreddit.data.repository.PostListRepository
 import com.cosmos.unreddit.data.repository.PreferencesRepository
 import com.cosmos.unreddit.di.DispatchersModule.DefaultDispatcher
 import com.cosmos.unreddit.ui.base.BaseViewModel
+import com.cosmos.unreddit.util.extension.latest
 import com.cosmos.unreddit.util.extension.updateValue
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -12,12 +14,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SubscriptionsViewModel @Inject constructor(
     preferencesRepository: PreferencesRepository,
-    repository: PostListRepository,
+    private val repository: PostListRepository,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
 ) : BaseViewModel(preferencesRepository, repository) {
 
@@ -32,5 +35,13 @@ class SubscriptionsViewModel @Inject constructor(
 
     fun setSearchQuery(query: String) {
         _searchQuery.updateValue(query)
+    }
+
+    fun unsubscribe(subscription: Subscription) {
+        viewModelScope.launch {
+            currentProfile.latest?.let {
+                repository.unsubscribe(subscription.name, it.id)
+            }
+        }
     }
 }

--- a/app/src/main/res/drawable/profile_selected_ring.xml
+++ b/app/src/main/res/drawable/profile_selected_ring.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="2dp"
+        android:color="@color/colorPrimary" />
+</shape>

--- a/app/src/main/res/layout/item_new_profile_home.xml
+++ b/app/src/main/res/layout/item_new_profile_home.xml
@@ -10,16 +10,24 @@
         android:layout_marginVertical="8dp"
         tools:layout_width="92dp">
 
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/image_add"
-            android:layout_width="@dimen/profile_home_size"
-            android:layout_height="@dimen/profile_home_size"
-            android:layout_gravity="center_horizontal"
-            android:background="@color/profile_new_background"
-            android:contentDescription="@string/profile_manager_add_profile"
-            app:contentPadding="6dp"
-            app:shapeAppearanceOverlay="@style/CircularImageViewStyle"
-            app:srcCompat="@drawable/ic_add" />
+        <!-- Same reserved box as a profile row so every avatar in the tray lines up -->
+        <FrameLayout
+            android:layout_width="@dimen/profile_home_ring_size"
+            android:layout_height="@dimen/profile_home_ring_size"
+            android:layout_gravity="center_horizontal">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/image_add"
+                android:layout_width="@dimen/profile_home_size"
+                android:layout_height="@dimen/profile_home_size"
+                android:layout_gravity="center"
+                android:background="@color/profile_new_background"
+                android:contentDescription="@string/profile_manager_add_profile"
+                app:contentPadding="6dp"
+                app:shapeAppearanceOverlay="@style/CircularImageViewStyle"
+                app:srcCompat="@drawable/ic_add" />
+
+        </FrameLayout>
 
         <TextView
             android:id="@+id/label_add"

--- a/app/src/main/res/layout/item_new_profile_home.xml
+++ b/app/src/main/res/layout/item_new_profile_home.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginVertical="8dp"
+        tools:layout_width="92dp">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/image_add"
+            android:layout_width="@dimen/profile_home_size"
+            android:layout_height="@dimen/profile_home_size"
+            android:layout_gravity="center_horizontal"
+            android:background="@color/profile_new_background"
+            android:contentDescription="@string/profile_manager_add_profile"
+            app:contentPadding="6dp"
+            app:shapeAppearanceOverlay="@style/CircularImageViewStyle"
+            app:srcCompat="@drawable/ic_add" />
+
+        <TextView
+            android:id="@+id/label_add"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:layout_marginTop="@dimen/profile_name_margin"
+            android:text="@string/profile_manager_add_profile" />
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_profile_home.xml
+++ b/app/src/main/res/layout/item_profile_home.xml
@@ -16,26 +16,41 @@
         android:layout_marginVertical="8dp"
         tools:layout_width="92dp">
 
-        <com.cosmos.unreddit.ui.common.widget.AvatarView
-            android:id="@+id/profile_avatar"
-            android:layout_width="@dimen/profile_home_size"
-            android:layout_height="@dimen/profile_home_size"
-            android:layout_gravity="center_horizontal"
-            app:text="@{profile.name}"
-            tools:text="S"/>
+        <!--
+        The ring is a sibling rather than a background on the avatar so that the space it needs is
+        reserved whether or not it is visible, keeping every row the same height.
+        -->
+        <FrameLayout
+            android:layout_width="@dimen/profile_home_ring_size"
+            android:layout_height="@dimen/profile_home_ring_size"
+            android:layout_gravity="center_horizontal">
+
+            <View
+                android:id="@+id/profile_selected_ring"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/profile_selected_ring"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <com.cosmos.unreddit.ui.common.widget.AvatarView
+                android:id="@+id/profile_avatar"
+                android:layout_width="@dimen/profile_home_size"
+                android:layout_height="@dimen/profile_home_size"
+                android:layout_gravity="center"
+                app:text="@{profile.name}"
+                tools:text="S" />
+
+        </FrameLayout>
 
         <TextView
             android:id="@+id/profile_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/profile_avatar"
-            app:layout_constraintBottom_toBottomOf="parent"
             android:gravity="center"
             android:layout_marginTop="@dimen/profile_name_margin"
             android:text="@{profile.name}"
-            tools:text="Profile"/>
+            tools:text="Profile" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -160,6 +160,8 @@
     <dimen name="backup_operation_card_height">84dp</dimen>
 
     <dimen name="profile_home_size">36dp</dimen>
+    <!-- Leaves room for the active-profile ring, so rows do not resize when the selection moves -->
+    <dimen name="profile_home_ring_size">46dp</dimen>
     <dimen name="profile_home_app_bar_size">32dp</dimen>
     <dimen name="profile_home_drawer_width">92dp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
 
     <string name="dialog_delete_profile_title">Delete Profile</string>
     <string name="dialog_delete_profile_message">Are you sure you want to delete this profile?\nSubscriptions, history and saved items for this profile will be lost.</string>
+    <string name="dialog_delete_profile_named_message">Are you sure you want to delete %1$s?\nSubscriptions, history and saved items for this profile will be lost.</string>
 
     <string name="dialog_unsubscribe_title">Remove Subscription</string>
     <string name="dialog_unsubscribe_message">Are you sure you want to remove %1$s from your subscriptions?</string>
@@ -220,6 +221,7 @@
     <string name="profile_name_length_error">Profile name must be between 3 and 20 characters</string>
     <string name="profile_already_exists_error">Profile already exists</string>
     <string name="profile_blank_error">Profile name cannot be blank</string>
+    <string name="profile_delete_current_error">The profile in use cannot be deleted</string>
 
     <string name="profile_manager_add_profile">Add Profile</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,9 @@
     <string name="dialog_delete_profile_title">Delete Profile</string>
     <string name="dialog_delete_profile_message">Are you sure you want to delete this profile?\nSubscriptions, history and saved items for this profile will be lost.</string>
 
+    <string name="dialog_unsubscribe_title">Remove Subscription</string>
+    <string name="dialog_unsubscribe_message">Are you sure you want to remove %1$s from your subscriptions?</string>
+
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_yes">Yes</string>
     <string name="dialog_no">No</string>


### PR DESCRIPTION
@RohitSurwase 

This adds some basic UX improvements to the Subscriptions and Profile views. For Subscriptions, you can long tap on a subscribed subreddit and remove it, which was previous impossible if the subreddit had been deleted or otherwise made inaccessible. 

The Profiles panel has also been made more functional by being able to long tap to delete a profile, as well as a button to add a new profile (which I believe was only previously possible by importing a backed-up file). It also adds an indicator for the currently selected profile.